### PR TITLE
Remove duplicate export `RtspAuthConfig`

### DIFF
--- a/lib/components/auth/index.ts
+++ b/lib/components/auth/index.ts
@@ -3,6 +3,7 @@ import { statusCode } from '../../utils/protocols/rtsp'
 import { Tube } from '../component'
 import { Message, MessageType, RtspMessage } from '../message'
 import { createTransform } from '../messageStreams'
+import { RtspConfig } from '../rtsp-session'
 import { DigestAuth } from './digest'
 import { parseWWWAuthenticate } from './www-authenticate'
 
@@ -11,6 +12,11 @@ const UNAUTHORIZED = 401
 export interface AuthConfig {
   username?: string
   password?: string
+}
+
+export interface RtspAuthConfig {
+  rtsp?: RtspConfig
+  auth?: AuthConfig
 }
 
 const DEFAULT_CONFIG = {

--- a/lib/pipelines/cli-mjpeg-pipeline.ts
+++ b/lib/pipelines/cli-mjpeg-pipeline.ts
@@ -1,14 +1,8 @@
-import { Auth, AuthConfig } from '../components/auth'
+import { Auth, RtspAuthConfig } from '../components/auth'
 import { RtspMjpegPipeline } from './rtsp-mjpeg-pipeline'
 import { TcpSource } from '../components/tcp'
 import { MessageType } from '../components/message'
 import { Sink } from '../components/component'
-import { RtspConfig } from '../components/rtsp-session'
-
-interface RtspAuthConfig {
-  rtsp?: RtspConfig
-  auth?: AuthConfig
-}
 
 /**
  * CliMjpegPipeline

--- a/lib/pipelines/cli-mp4-pipeline.ts
+++ b/lib/pipelines/cli-mp4-pipeline.ts
@@ -1,14 +1,8 @@
-import { RtspConfig } from '../components/rtsp-session'
 import { TcpSource } from '../components/tcp'
 import { RtspMp4Pipeline } from './rtsp-mp4-pipeline'
 import { MessageType } from '../components/message'
-import { AuthConfig, Auth } from '../components/auth'
+import { RtspAuthConfig, Auth } from '../components/auth'
 import { Sink } from '../components/component'
-
-interface RtspAuthConfig {
-  rtsp?: RtspConfig
-  auth?: AuthConfig
-}
 
 /**
  * CliMp4Pipeline


### PR DESCRIPTION
Fixes Typescript error:

```
node_modules/@clockworkdog/media-stream-library-node/dist/index.d.ts:1660:5 - error TS2308: Module "pipelines/cli-mjpeg-pipeline" has already exported a member named RtspAuthConfig. Consider explicitly re-exporting to resolve the ambiguity.

1660     export * from "pipelines/cli-mp4-pipeline";
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```